### PR TITLE
Add sysmacros include file for commands-pisix file

### DIFF
--- a/configure
+++ b/configure
@@ -4158,6 +4158,21 @@ if compile_prog "" "" ; then
     getauxval=yes
 fi
 
+
+##########################################
+# check for sysmacros.h
+
+have_sysmacros=no
+cat > $TMPC << EOF
+#include <sys/sysmacros.h>
+int main(void) {
+    return makedev(0, 0);
+}
+EOF
+if compile_prog "" "" ; then
+    have_sysmacros=yes
+fi
+
 ##########################################
 # End of CC checks
 # After here, no more $cc or $ld runs
@@ -4954,6 +4969,9 @@ echo "CONFIG_TRACE_FILE=$trace_file" >> $config_host_mak
 
 if test "$rdma" = "yes" ; then
   echo "CONFIG_RDMA=y" >> $config_host_mak
+fi
+if test "$have_sysmacros" = "yes" ; then
+  echo "CONFIG_SYSMACROS=y" >> $config_host_mak
 fi
 
 # Hold two types of flag:

--- a/qga/commands-posix.c
+++ b/qga/commands-posix.c
@@ -29,6 +29,10 @@
 #include "qemu/queue.h"
 #include "qemu/host-utils.h"
 
+#ifdef CONFIG_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
+
 #ifndef CONFIG_HAS_ENVIRON
 #ifdef __APPLE__
 #include <crt_externs.h>


### PR DESCRIPTION
In newer version of Linux, the definition of some commands has moved into this file and it should be manually included to avoid compilation and installation failure.

Please refer to [http://patchwork.ozlabs.org/patch/709415/](http://patchwork.ozlabs.org/patch/709415/) and 
[https://github.com/qemu/qemu/blob/master/include/sysemu/os-posix.h](https://github.com/qemu/qemu/blob/master/include/sysemu/os-posix.h).

System Version: The original files could not install on Ubuntu 19.10 and will work fine after this change.